### PR TITLE
Output log snippet in Slack

### DIFF
--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -29,8 +29,8 @@ def lambda_handler(event, context):
     message = []
     timestamp = event['time'].split(".")[0]
     timestamp = datetime.strptime(timestamp[:-1], '%Y-%m-%dT%H:%M:%S')
+    message.append("Execution: " + executionname)
     message.append("Time: " + str(timestamp))
-    message.append("Executionname: " + executionname)
     message.append("Status: No issues")
 
     if (color == "danger"):
@@ -41,20 +41,21 @@ def lambda_handler(event, context):
         try:
             for eventer in output["events"]:
                 if ("ExecutionFailed" in eventer["type"]):
-                    cause = str(eventer["executionFailedEventDetails"]["cause"])
-                    aktivitity = cause.split("'")[1]
-																					 
+                    cause = "```" + str(eventer["executionFailedEventDetails"]["cause"]) + "```"
+                    error_code = str(eventer["executionFailedEventDetails"]["error"])
+
         except Exception:
-            aktivitity = 'Unknown'
+            logger.exception('Something went wrong when parsing execution details')
             cause = 'Unknown'
-        message[2]= ("Failed: " + aktivitity + "\n" + " Error: " + cause)
-        
+            error_code = 'Unknown'
+        message[2]= ("Status: Failed\nError: {error_code}\n" + cause)
+
     slack_attachment = {
         "attachments": [
             {
                 "title": pipelinename + "-" + event['detail']['status'],
                 "fallback": "fallback",
-                "text": message[0] + "\n" + message[1] + "\n" + message[2],
+                "text": "\n".join(message),
                 "color": color,
                 "mrkdwn_in": [
                     "text"

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -48,7 +48,7 @@ def lambda_handler(event, context):
             logger.exception('Something went wrong when parsing execution details')
             cause = 'Unknown'
             error_code = 'Unknown'
-        message[2]= ("Status: Failed\nError: {error_code}\n" + cause)
+        message[2]= (f"Status: Failed\nError: {error_code}\n" + cause)
 
     slack_attachment = {
         "attachments": [

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -31,9 +31,9 @@ def lambda_handler(event, context):
     timestamp = datetime.strptime(timestamp[:-1], '%Y-%m-%dT%H:%M:%S')
     message.append("*Execution:* " + executionname)
     message.append("*Time:* " + str(timestamp))
-    if event['detail']['status'] == "RUNNING":
+    if event['detail']['status'] == "RUNNING":
         message.append("*Status:* Started")
-    elif event['detail']['status'] == "SUCCEEDED":
+    elif event['detail']['status'] == "SUCCEEDED":
         message.append("*Status:* Successfully finished")
 
     if (color == "danger"):

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -44,8 +44,8 @@ def lambda_handler(event, context):
         try:
             for eventer in output["events"]:
                 if ("ExecutionFailed" in eventer["type"]):
-                    cause = "```" + str(eventer["executionFailedEventDetails"]["cause"]) + "```"
-                    error_code = str(eventer["executionFailedEventDetails"]["error"])
+                    cause = "```" + str(eventer["executionFailedEventDetails"].get("cause", "Unknown")) + "```"
+                    error_code = str(eventer["executionFailedEventDetails"].get("error", "Unknown error"))
 
         except Exception:
             logger.exception('Something went wrong when parsing execution details')


### PR DESCRIPTION
- Improve message formatting a bit using emphasized text
- Output the Step Function's `error` and `cause` if something goes wrong. E.g., in the case of a failed deployment, this will be an error code and a log snippet, respectively.

Does not seem like the API currently supports a straight-forward way of getting the name of the state that failed. The previous method tried to extract the state name using pattern matching, but the error message it relied on seldom appears.