### PR TITLE
Output name of failed state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,10 +19,11 @@ resource "aws_lambda_function" "stepfunction_status_slack" {
   runtime          = "python3.7"
   filename         = data.archive_file.lambda_stepfunction_status_slack_src.output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_stepfunction_status_slack_src.output_path)
+  timeout          = var.lambda_timeout
   tags             = var.tags
   environment {
     variables = {
-      slackwebhook = var.slackwebhook
+      slackwebhook   = var.slackwebhook
       statestonotify = var.statestonotify
     }
   }

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -7,29 +7,66 @@ from datetime import datetime
 from urllib import request
 
 logger = logging.getLogger()
-formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s', '%Y-%m-%d %H:%M:%S')
-for h in logger.handlers:
-    h.setFormatter(formatter)
 logger.setLevel(logging.INFO)
+
+
+def get_name_of_last_entered_state(event, events):
+    """Backtracks to the last entered state of the execution and returns the name of it"""
+    if event["type"].endswith('StateEntered'):
+        return event["stateEnteredEventDetails"]["name"]
+    previous_id = event["previousEventId"]
+    previous_event = next(
+        (e for e in events if e["id"] == previous_id), None)
+    if previous_event is None:
+        return None
+    return get_name_of_last_entered_state(previous_event, events)
+
+
+def get_failed_message(execution_arn, client=None):
+    if client is None:
+        client = boto3.client('stepfunctions')
+    response = client.get_execution_history(
+        executionArn=execution_arn,
+        maxResults=500,
+        reverseOrder=True
+    )
+    events = response["events"]
+    failed_event = next(
+        (event for event in events if event["type"] == "ExecutionFailed"), None)
+    state_name = "Unknown state"
+    cause = 'Unknown'
+    error_code = 'Unknown error'
+    if failed_event:
+        state_name = get_name_of_last_entered_state(
+            failed_event, events) or state_name
+        cause = failed_event['executionFailedEventDetails']['cause']
+        error_code = failed_event['executionFailedEventDetails']['error']
+    return (f"*Status:* Failed in state `{state_name}`\n"
+            f"*Error:* `{error_code}`\n"
+            f"```{cause}```"
+            )
 
 
 def lambda_handler(event, context):
     logger.info(event)
+    region = os.environ['AWS_REGION']
     slack_webhook_url = os.environ['slackwebhook']
     state_to_notify = os.environ['statestonotify']
 
-    color = "danger" if event['detail']['status'] in ["FAILED", "ABORTED", "TIMED_OUT"] else "good"
+    color = "danger" if event['detail']['status'] in [
+        "FAILED", "ABORTED", "TIMED_OUT"] else "good"
 
     # Send message to slack
     pipelinename = event['detail']['stateMachineArn']
     pipelinename = pipelinename.split(":")[6]
     executionarn = event['detail']['executionArn']
     executionname = executionarn.split(":")[7]
+    execution_url = f"https://console.aws.amazon.com/states/home?region={region}#/executions/details/{executionarn}"
 
     message = []
     timestamp = event['time'].split(".")[0]
     timestamp = datetime.strptime(timestamp[:-1], '%Y-%m-%dT%H:%M:%S')
-    message.append("*Execution:* " + executionname)
+    message.append(f"*Execution:* <{execution_url}|{executionname}>")
     message.append("*Time:* " + str(timestamp))
     if event['detail']['status'] == "RUNNING":
         message.append("*Status:* Started")
@@ -37,21 +74,8 @@ def lambda_handler(event, context):
         message.append("*Status:* Successfully finished")
 
     if (color == "danger"):
-        client = boto3.client("stepfunctions")
-        output = client.get_execution_history(executionArn=executionarn)
-        logger.info('\nFailed ' + str(output))
-
-        try:
-            for eventer in output["events"]:
-                if ("ExecutionFailed" in eventer["type"]):
-                    cause = "```" + str(eventer["executionFailedEventDetails"].get("cause", "Unknown")) + "```"
-                    error_code = str(eventer["executionFailedEventDetails"].get("error", "Unknown error"))
-
-        except Exception:
-            logger.exception('Something went wrong when parsing execution details')
-            cause = 'Unknown'
-            error_code = 'Unknown error'
-        message.append(f"*Status:* Failed\n*Error:* {error_code}\n" + cause)
+        failed_message = get_failed_message(executionarn)
+        message.append(failed_message)
 
     slack_attachment = {
         "attachments": [
@@ -72,7 +96,7 @@ def lambda_handler(event, context):
         logger.info('\nOutput ' + str(json_data))
         if (color == "danger" or state_to_notify == "all"):
             slack_request = urllib.request.Request(slack_webhook_url, data=json_data.encode('ascii'),
-                                                headers={'Content-Type': 'application/json'})
+                                                   headers={'Content-Type': 'application/json'})
             slack_response = urllib.request.urlopen(slack_request)
     except Exception as em:
         logger.exception("EXCEPTION: " + str(em))

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -84,6 +84,9 @@ def lambda_handler(event, context):
     elif status == "TIMED_OUT":
         slack_color = 'danger'
         slack_message.append('*Status:* Execution timed out')
+    else:
+        slack_color = 'danger'
+        slack_message.append(f'*Status:* Unknown execution status `{status}`')
 
     slack_attachment = {
         "attachments": [

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -12,11 +12,10 @@ logger.setLevel(logging.INFO)
 
 def get_name_of_last_entered_state(event, events):
     """Backtracks to the last entered state of the execution and returns the name of it"""
-    if event["type"].endswith('StateEntered'):
+    if event["type"].endswith("StateEntered"):
         return event["stateEnteredEventDetails"]["name"]
     previous_id = event["previousEventId"]
-    previous_event = next(
-        (e for e in events if e["id"] == previous_id), None)
+    previous_event = next((e for e in events if e["id"] == previous_id), None)
     if previous_event is None:
         return None
     return get_name_of_last_entered_state(previous_event, events)
@@ -24,56 +23,59 @@ def get_name_of_last_entered_state(event, events):
 
 def get_failed_message(execution_arn, client=None):
     if client is None:
-        client = boto3.client('stepfunctions')
+        client = boto3.client("stepfunctions")
     response = client.get_execution_history(
-        executionArn=execution_arn,
-        maxResults=500,
-        reverseOrder=True
+        executionArn=execution_arn, maxResults=500, reverseOrder=True
     )
     events = response["events"]
     failed_event = next(
-        (event for event in events if event["type"] == "ExecutionFailed"), None)
+        (event for event in events if event["type"] == "ExecutionFailed"), None
+    )
     state_name = "Unknown state"
-    cause = 'Unknown'
-    error_code = 'Unknown error'
+    cause = "Unknown"
+    error_code = "Unknown error"
     if failed_event:
         state_name = get_name_of_last_entered_state(
             failed_event, events) or state_name
-        cause = failed_event['executionFailedEventDetails']['cause']
-        error_code = failed_event['executionFailedEventDetails']['error']
-    return (f"*Status:* Failed in state `{state_name}`\n"
-            f"*Error:* `{error_code}`\n"
-            f"```{cause}```"
-            )
+        cause = failed_event["executionFailedEventDetails"]["cause"]
+        error_code = failed_event["executionFailedEventDetails"]["error"]
+    return (
+        f"*Status:* Failed in state `{state_name}`\n"
+        f"*Error:* `{error_code}`\n"
+        f"```{cause}```"
+    )
 
 
 def lambda_handler(event, context):
     logger.info(event)
-    region = os.environ['AWS_REGION']
-    slack_webhook_url = os.environ['slackwebhook']
-    state_to_notify = os.environ['statestonotify']
+    region = os.environ["AWS_REGION"]
+    slack_webhook_url = os.environ["slackwebhook"]
+    state_to_notify = os.environ["statestonotify"]
 
-    color = "danger" if event['detail']['status'] in [
-        "FAILED", "ABORTED", "TIMED_OUT"] else "good"
+    color = (
+        "danger"
+        if event["detail"]["status"] in ["FAILED", "ABORTED", "TIMED_OUT"]
+        else "good"
+    )
 
     # Send message to slack
-    pipelinename = event['detail']['stateMachineArn']
+    pipelinename = event["detail"]["stateMachineArn"]
     pipelinename = pipelinename.split(":")[6]
-    executionarn = event['detail']['executionArn']
+    executionarn = event["detail"]["executionArn"]
     executionname = executionarn.split(":")[7]
     execution_url = f"https://console.aws.amazon.com/states/home?region={region}#/executions/details/{executionarn}"
 
     message = []
-    timestamp = event['time'].split(".")[0]
-    timestamp = datetime.strptime(timestamp[:-1], '%Y-%m-%dT%H:%M:%S')
+    timestamp = event["time"].split(".")[0]
+    timestamp = datetime.strptime(timestamp[:-1], "%Y-%m-%dT%H:%M:%S")
     message.append(f"*Execution:* <{execution_url}|{executionname}>")
     message.append("*Time:* " + str(timestamp))
-    if event['detail']['status'] == "RUNNING":
+    if event["detail"]["status"] == "RUNNING":
         message.append("*Status:* Started")
-    elif event['detail']['status'] == "SUCCEEDED":
+    elif event["detail"]["status"] == "SUCCEEDED":
         message.append("*Status:* Successfully finished")
 
-    if (color == "danger"):
+    if color == "danger":
         failed_message = get_failed_message(executionarn)
         message.append(failed_message)
 
@@ -84,19 +86,20 @@ def lambda_handler(event, context):
                 "fallback": "fallback",
                 "text": "\n".join(message),
                 "color": color,
-                "mrkdwn_in": [
-                    "text"
-                ]
+                "mrkdwn_in": ["text"],
             }
         ]
     }
 
     try:
         json_data = json.dumps(slack_attachment)
-        logger.info('\nOutput ' + str(json_data))
-        if (color == "danger" or state_to_notify == "all"):
-            slack_request = urllib.request.Request(slack_webhook_url, data=json_data.encode('ascii'),
-                                                   headers={'Content-Type': 'application/json'})
+        logger.info("\nOutput " + str(json_data))
+        if color == "danger" or state_to_notify == "all":
+            slack_request = urllib.request.Request(
+                slack_webhook_url,
+                data=json_data.encode("ascii"),
+                headers={"Content-Type": "application/json"},
+            )
             slack_response = urllib.request.urlopen(slack_request)
     except Exception as em:
         logger.exception("EXCEPTION: " + str(em))

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,10 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "lambda_timeout" {
+  description = "The maximum number of seconds the Lambda is allowed to run"
+  default     = 10
+}
+
+


### PR DESCRIPTION
- Outputs the name of the failed state (e.g., `Deploy Prod`) to Slack
- Refactor, formatting, linting