### PR TITLE
Consider timed out states as failed

### DIFF
--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -36,7 +36,7 @@ def get_fail_events(events, excluded_states=[]):
         # Different state types use different names for storing details about the failed event
         # `taskFailedEventDetails`, `activityFailedEventDetails`, etc.
         failed_event_details = e.get(next((key for key in e if (key.endswith(
-            "FailedEventDetails") or key.endswith("TimedOutEventDetails")) and all(required_key in e[key] for required_key in ["error", "cause"])), None), None)
+            "FailedEventDetails") or key.endswith("TimedOutEventDetails")) and all(required_key in e[key] for required_key in ["error"])), None), None)
         if failed_event_details and (e["type"].endswith("Failed") or e["type"].endswith("TimedOut")) and e["type"] != "ExecutionFailed":
             enter_event = find_event_by_backtracking(e, events, lambda current_event: current_event["type"].endswith("StateEntered") and current_event["stateEnteredEventDetails"]["name"] not in excluded_states, break_fn=lambda visited_events: any(
                 visited_event["type"].endswith("StateEntered") for visited_event in visited_events))
@@ -64,12 +64,15 @@ def get_failed_message(execution_arn, client=None):
             return (
                 f"*Status:* Failed in state `{fail_events[0]['name']}`\n"
                 f"*Error:* `{fail_events[0]['failedEventDetails']['error']}`\n"
-                f"```{fail_events[0]['failedEventDetails'].get('cause', '')}```"
+                f"{'```' + fail_events[0]['failedEventDetails']['cause'] + '```' if 'cause' in fail_events[0]['failedEventDetails'] else ''}"
             )
         else:
             state_names = ', '.join([f"`{e['name']}`" for e in fail_events])
             errors = "\n".join(
-                [f"`{e['name']}` failed due to `{e['failedEventDetails']['error']}`:\n```{e['failedEventDetails'].get('cause', '')}```" for e in fail_events])
+                [(
+                    f"`{e['name']}` failed due to `{e['failedEventDetails']['error']}`:\n"
+                    f"{'```' + e['failedEventDetails']['cause'] + '```' if 'cause' in e['failedEventDetails'] else ''}"
+                ) for e in fail_events])
             return (
                 f"*Status:* Failed in states {state_names}\n"
                 f"*Errors:*\n"


### PR DESCRIPTION
An execution that fails due to a timed out task will currently report `Unknown error` and `Unknown` cause to Slack. Relevant data for this kind of failure type is already included in the events of type `TaskTimedOut`, so this PR uses that information if necessary.

A caveat here is that the `TimedOutEventDetails` does not include a `cause` key, only an `error` key, so the Lambda logic had to be updated to handle that.