### PR TITLE
Add more details to Slack message

### DIFF
--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -105,8 +105,7 @@ def lambda_handler(event, context):
     toggling_cost_saving_mode = execution_input.get(
         "toggling_cost_saving_mode", False)
     slack_message = [
-        f"*Execution:* <{execution_url}|{execution_name}>",
-        f"*Time:* {timestamp}"
+        f"*Execution:* <{execution_url}|{execution_name}>"
     ]
     footer = ""
     if all(key in execution_input for key in ["git_user", "git_repo", "git_branch"]):
@@ -146,6 +145,7 @@ def lambda_handler(event, context):
                 "color": slack_color,
                 "mrkdwn_in": ["text"],
                 "footer": footer,
+                "ts": int(timestamp.timestamp())
             }
         ]
     }

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -3,6 +3,7 @@ import logging
 import json
 import urllib
 import boto3
+import uuid
 from datetime import datetime
 from urllib import request
 
@@ -107,9 +108,16 @@ def lambda_handler(event, context):
     slack_message = [
         f"*Execution:* <{execution_url}|{execution_name}>"
     ]
+    manually_triggered = False
+    try:
+        manually_triggered = str(uuid.UUID(execution_name)) == execution_name
+    except ValueError:
+        pass
     footer = ""
-    if all(key in execution_input for key in ["git_user", "git_repo", "git_branch"]):
-        footer = f"{execution_input['git_user']} @ {execution_input['git_repo']} ({execution_input['git_branch']})"
+    if manually_triggered:
+        footer = "Triggered by AWS Console"
+    elif all(key in execution_input for key in ["git_user", "git_repo", "git_branch"]):
+        footer = f"Triggered by {execution_input['git_user']} @ {execution_input['git_repo']} ({execution_input['git_branch']})"
 
     if toggling_cost_saving_mode:
         slack_message.append(

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -119,6 +119,7 @@ def lambda_handler(event, context):
     if status == 'RUNNING':
         slack_color = 'good'
         slack_message.append("*Status:* Started")
+        slack_message.append(f"**Execution Input**:\n```{json.dumps(execution_input, sort_keys=True)}```")
     elif status == 'SUCCEEDED':
         slack_color = 'good'
         slack_message.append("*Status:* Successfully finished")

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -118,7 +118,7 @@ def lambda_handler(event, context):
     if status == 'RUNNING':
         slack_color = 'good'
         slack_message.append("*Status:* Started")
-        slack_message.append(f"**Execution Input**:\n```{json.dumps(execution_input, sort_keys=True)}```")
+        slack_message.append(f"*Execution Input*:\n```{json.dumps(execution_input, sort_keys=True, indent=2)}```")
     elif status == 'SUCCEEDED':
         slack_color = 'good'
         slack_message.append("*Status:* Successfully finished")

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -108,6 +108,9 @@ def lambda_handler(event, context):
         f"*Execution:* <{execution_url}|{execution_name}>",
         f"*Time:* {timestamp}"
     ]
+    footer = ""
+    if all(key in execution_input for key in ["git_user", "git_repo", "git_branch"]):
+        footer = f"{execution_input['git_user']} @ {execution_input['git_repo']} ({execution_input['git_branch']})"
 
     if toggling_cost_saving_mode:
         slack_message.append(
@@ -141,6 +144,7 @@ def lambda_handler(event, context):
                 "text": "\n".join(slack_message),
                 "color": slack_color,
                 "mrkdwn_in": ["text"],
+                "footer": footer,
             }
         ]
     }

--- a/src/pipeline-status-slack.py
+++ b/src/pipeline-status-slack.py
@@ -126,7 +126,7 @@ def lambda_handler(event, context):
     if status == 'RUNNING':
         slack_color = 'good'
         slack_message.append("*Status:* Started")
-        slack_message.append(f"*Execution Input*:\n```{json.dumps(execution_input, sort_keys=True, indent=2)}```")
+        slack_message.append(f"*Input*:\n```{json.dumps(execution_input, sort_keys=True, indent=2)}```")
     elif status == 'SUCCEEDED':
         slack_color = 'good'
         slack_message.append("*Status:* Successfully finished")


### PR DESCRIPTION
- Add  execution JSON input to Slack message (can be helpful wrt. troubleshooting -- easy to see which repository triggered the pipeline, as well as which ZIP file will be deployed)
- Add details about triggering user, repo and branch (if available) to Slack message
- Check if the execution was manually triggered or not (automatically triggered executions follow a specific name convention `<sha>-<timestamp>`, while manually triggered executions are by default assigned a random UUID as name)
- Use built-in Slack API mechanism for timestamping as this handles timezone conversion for us

An example of the proposed Slack message format:
![Screenshot 2020-11-06 at 16 36 37](https://user-images.githubusercontent.com/10640491/98384643-545f4600-204e-11eb-9a68-fafd09b2f35e.png)
