### PR TITLE
Optional filtering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
     "Step Functions Execution Status Change"
   ],
   "detail": {
-    "stateMachineArn": ${jsonencode(length(var.state_machine_arns) > 0 ? var.state_machine_arns : "*")}
+    "stateMachineArn": ${length(var.state_machine_arns) > 0 ? jsonencode(var.state_machine_arns) : jsonencode("*")}
   }
 }
 EOF

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
   name        = "${var.name_prefix}-sfn-state-machine-update"
   description = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
+  tags        = var.tags
   event_pattern = <<EOF
 {
   "source": [

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
+  name        = "${var.name_prefix}-sfn-state-machine-update"
   description = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
   event_pattern = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
     "Step Functions Execution Status Change"
   ],
   "detail": {
-    "stateMachineArn": ${length(var.state_machine_arns) > 0 ? jsonencode(var.state_machine_arns) : jsonencode("*")}
+    "stateMachineArn": ${jsonencode(var.state_machine_arns)}
   }
 }
 EOF

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
-  name        = "${var.name_prefix}-sfn-state-machine-update"
+  name        = "${var.name_prefix}-sfn-execution-change"
   description = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
   tags        = var.tags
   event_pattern = <<EOF

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,8 @@ resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
     "stateMachineArn": ${
   length(var.state_machine_arns) > 0
   ? jsonencode(var.state_machine_arns)
-: jsonencode([{ exists = true }])}
+  # This pattern will match all state machine ARNs
+: jsonencode([{ prefix = "" }])}
   }
 }
 EOF

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
-  description   = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
+  description = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
   event_pattern = <<EOF
 {
   "source": [

--- a/main.tf
+++ b/main.tf
@@ -42,14 +42,17 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
   name = "stepfunction-${data.aws_caller_identity.current.account_id}-deploy-notifications-rule"
-  event_pattern =<<EOF
-    {
+  event_pattern = <<EOF
+{
   "source": [
     "aws.states"
   ],
   "detail-type": [
     "Step Functions Execution Status Change"
-  ]
+  ],
+  "detail": {
+    "stateMachineArn": ${jsonencode(length(var.state_machine_arns) > 0 ? var.state_machine_arns : "*")}
+  }
 }
 EOF
 }

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
-  name          = "stepfunction-${data.aws_caller_identity.current.account_id}-deploy-notifications-rule"
+  description   = "Triggers when an AWS Step Functions state machine execution starts, succeeds or fails"
   event_pattern = <<EOF
 {
   "source": [

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role_policy" "logs_to_stepfunction_status_slack_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
-  name = "stepfunction-${data.aws_caller_identity.current.account_id}-deploy-notifications-rule"
+  name          = "stepfunction-${data.aws_caller_identity.current.account_id}-deploy-notifications-rule"
   event_pattern = <<EOF
 {
   "source": [
@@ -58,7 +58,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "lambda_stepfunctions_notifications" {
-  arn = aws_lambda_function.stepfunction_status_slack.arn
+  arn  = aws_lambda_function.stepfunction_status_slack.arn
   rule = aws_cloudwatch_event_rule.deploy_events_rule.name
 }
 
@@ -68,3 +68,4 @@ resource "aws_lambda_permission" "allow_cloudwatch_stepfunction_notifications" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.deploy_events_rule.arn
 }
+

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,10 @@ resource "aws_cloudwatch_event_rule" "deploy_events_rule" {
     "Step Functions Execution Status Change"
   ],
   "detail": {
-    "stateMachineArn": ${jsonencode(var.state_machine_arns)}
+    "stateMachineArn": ${
+  length(var.state_machine_arns) > 0
+  ? jsonencode(var.state_machine_arns)
+: jsonencode([{ exists = true }])}
   }
 }
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "artifact_bucket_name" {
 
 variable "state_machine_arns" {
   description = "An optional list of ARNs of AWS Step Functions state machines to report updates on. Default behavior is to report updates for all state machines in the current region."
-  default     = []
+  default     = ["*"]
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "artifact_bucket_name" {
 
 variable "state_machine_arns" {
   description = "An optional list of ARNs of AWS Step Functions state machines to report updates on. Default behavior is to report updates for all state machines in the current region."
-  default     = ["*"]
+  default     = []
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "artifact_bucket_name" {
   default     = ""
 }
 
+variable "state_machine_arns" {
+  description = "An optional list of ARNs of AWS Step Functions state machines to report updates on. Default behavior is to report updates for all state machines in the current region."
+  default     = []
+  type        = list(string)
+}
+
 variable "slackwebhook" {
   description = "The slack webhook URL"
   type        = string


### PR DESCRIPTION
This PR adds a variable that can be used to control which state machines to listen to updates for.

The default behavior is to listen to updates for all state machines. If an account has multiple instantiations of this module, however, it can be useful to explicitly define a set of state machines to avoid getting duplicate messages sent to Slack.

The name of the CloudWatch Event rule has also been updated to utilize the name prefix to avoid potentially overwriting the configuration of an existing rule.