### PR TITLE
Handle executions with no `TaskFailed` events

### DIFF
--- a/src/.flake8
+++ b/src/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length=79


### PR DESCRIPTION
All failed execution contains an `ExecutionFailed` event. For typical failures (e.g., one or more `Deploy ...` states fail), the error description is contained in the `TaskFailed` event for the respective states, and we thus skip the `ExecutionFailed` when looking for error details. However, certain execution failures do not contain any `TaskFailed` events. In these cases we do, however, need to look at the `ExecutionFailed` event for details. This typically occurs if the state machine definition is referencing a JSON key that does not exist in the input JSON.

This PR handles the case of an execution failing without any `TaskFailed` events, and includes the details found in the `ExecutionFailed` when constructing the Slack message.

Some minimal formatting and linting is also included.